### PR TITLE
Switch internal docker address to linux

### DIFF
--- a/backend/.env
+++ b/backend/.env
@@ -1,5 +1,5 @@
 API_PATH = 'http://localhost:3000'
-DOCKER_ADDRESS = '192.168.1.12'
+DOCKER_ADDRESS = '172.17.0.1'
 LOCAL_ADDRESS = '127.0.0.1'
 
 DB_TYPE = 'mysql'


### PR DESCRIPTION
The Docker address was set to 192.168.1.12, which is the internal docker address for windows. It has now been changed to 172.17.0.1 to work on the Linux virtual machine.